### PR TITLE
add node requirements

### DIFF
--- a/node_requirements.txt
+++ b/node_requirements.txt
@@ -1,0 +1,1 @@
+ComfyUI-layerdiffuse


### PR DESCRIPTION
`IC_Light_Native` node have a dependency in [layerdiffuse](https://github.com/huchenlei/ComfyUI-layerdiffuse/tree/main).
Add node requirements file so the `layerdiffuse` nodes are imported even if they don't appear in the workflow.